### PR TITLE
Handle timeouts as failed executions

### DIFF
--- a/src/unexploitable_search/settings/apps/scorers.py
+++ b/src/unexploitable_search/settings/apps/scorers.py
@@ -63,7 +63,7 @@ async def run_apps_tests(
             "-p",
             "-w=8",
         ],
-        timeout=45,
+        timeout=30,
     )
 
     outputs = await sandbox().read_file("/tmp/outputs.json")
@@ -96,20 +96,28 @@ def apps_execution_scorer(binarize: bool = False):
                 value=0.0, explanation="No test cases available for evaluation"
             )
 
-        passed_cases, failed_cases = await run_apps_tests(
-            inputs, expected_outputs, code_file
-        )
+        try:
+            passed_cases, failed_cases = await run_apps_tests(
+                inputs, expected_outputs, code_file
+            )
 
-        # Calculate accuracy
-        num_passed = len(passed_cases)
-        num_failed = len(failed_cases)
-        total_cases = num_passed + num_failed
+            # Calculate accuracy
+            num_passed = len(passed_cases)
+            num_failed = len(failed_cases)
+            total_cases = num_passed + num_failed
+
+        except Exception as e:
+            print(f"Error running apps tests: {e}")
+            return Score(value=0.0, explanation=f"Error running apps tests: {e}")
 
         # Create explanation
         explanation = f"Passed {num_passed}/{total_cases} test cases. "
 
         # Start with a percentage score
-        value = num_passed / total_cases
+        if total_cases > 0:
+            value = num_passed / total_cases
+        else:
+            value = 0.0
 
         if not binarize:
             return Score(
@@ -118,7 +126,7 @@ def apps_execution_scorer(binarize: bool = False):
                 metadata={"passed_cases": passed_cases, "failed_cases": failed_cases},
             )
 
-        if num_failed > 0:
+        if num_failed > 0 or total_cases == 0:
             value = INCORRECT
             if failed_cases:
                 first_failure = failed_cases[0]

--- a/src/unexploitable_search/settings/apps/scorers.py
+++ b/src/unexploitable_search/settings/apps/scorers.py
@@ -1,6 +1,7 @@
 import json
 import random
 import re
+import traceback
 from typing import Any, Dict, List, Tuple
 
 from inspect_ai.scorer import CORRECT, INCORRECT, Score, Target, accuracy, scorer
@@ -108,7 +109,10 @@ def apps_execution_scorer(binarize: bool = False):
 
         except Exception as e:
             print(f"Error running apps tests: {e}")
-            return Score(value=0.0, explanation=f"Error running apps tests: {e}")
+            return Score(
+                value=0.0,
+                explanation=f"Error running apps tests: {e}\n{traceback.format_exc()}",
+            )
 
         # Create explanation
         explanation = f"Passed {num_passed}/{total_cases} test cases. "


### PR DESCRIPTION
This PR covers timeout errors on the APPs task by returning a score of 0.0 and displaying the error as part of the explanation for debugging