### PR TITLE
scripts for investigating BoN

### DIFF
--- a/scripts/experiments/run_all_side_quests.py
+++ b/scripts/experiments/run_all_side_quests.py
@@ -53,6 +53,7 @@ def main(
             tasks.append(
                 alpaca_benign(
                     temperature=temperature,
+                    score_side_quests=True,
                 )
             )
 

--- a/scripts/experiments/run_bon_sanity_check.py
+++ b/scripts/experiments/run_bon_sanity_check.py
@@ -1,0 +1,19 @@
+from inspect_ai import eval_set
+
+from unexploitable_search.config.core import create_new_run_dir
+from unexploitable_search.settings.alpaca.tasks import alpaca_benign
+
+models = ["openrouter/openai/gpt-5-nano", "openrouter/meta-llama/llama-3.1-8b-instruct"]
+
+ns = [1, 2, 4, 8, 16]
+
+tasks = [
+    alpaca_benign(
+        n_best_of_n=n,
+    )
+    for n in ns
+]
+
+run_dir = create_new_run_dir("bon_sanity_check")
+
+eval_set(model=models, tasks=tasks, log_dir=str(run_dir), limit=50)

--- a/scripts/plots/plot_bon_sanity_check.py
+++ b/scripts/plots/plot_bon_sanity_check.py
@@ -1,0 +1,76 @@
+import argparse
+
+import matplotlib.pyplot as plt
+import pandas as pd  # type: ignore
+from inspect_ai.analysis import EvalColumn, EvalScores, evals_df
+from inspect_ai.log import list_eval_logs
+
+
+def plot_performance(df: pd.DataFrame):
+    if "n_best_of_n" not in df.columns or "model" not in df.columns:
+        raise ValueError("DataFrame must contain 'n_best_of_n' and 'model' columns.")
+
+    accuracy_cols = [col for col in df.columns if col.endswith("_accuracy")]
+    if not accuracy_cols:
+        raise ValueError("No accuracy columns found in DataFrame.")
+
+    plt.figure(figsize=(8, 6))
+
+    models = df["model"].unique()
+    colours = plt.cm.get_cmap("tab10", len(models))
+
+    n_best_of_n_values = sorted(df["n_best_of_n"].unique())
+    if all(float(x).is_integer() for x in n_best_of_n_values):
+        n_best_of_n_values = [int(x) for x in n_best_of_n_values]
+
+    for i, model in enumerate(models):
+        model_df = df[df["model"] == model]
+        for acc_col in accuracy_cols:
+            plot_df = model_df.sort_values("n_best_of_n")  # type: ignore [this is forced to be an int in evals_df but the type check refuses to believe]
+            plt.plot(
+                plot_df["n_best_of_n"],
+                plot_df[acc_col],
+                marker="o",
+                label=f"{model} ({acc_col.replace('_accuracy', '')})"
+                if len(accuracy_cols) > 1
+                else model,
+                color=colours(i),
+            )
+
+    plt.xscale("log")
+    plt.xlabel("n_best_of_n")
+    plt.ylabel("Accuracy")
+    plt.ylim(0, 1)
+    plt.title("Accuracy vs n_best_of_n")
+    plt.legend()
+
+    plt.xticks(n_best_of_n_values, [str(x) for x in n_best_of_n_values])
+    plt.gca().set_xticks(n_best_of_n_values, minor=False)
+    plt.gca().set_xticks([], minor=True)
+
+    plt.grid(True, which="major", axis="x", linestyle="--", alpha=0.5)
+    plt.grid(True, which="major", axis="y", linestyle="--", alpha=0.5)
+    plt.tight_layout()
+    plt.show()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-dir", type=str, required=True)
+    args = parser.parse_args()
+    logs_info = list_eval_logs(args.run_dir)
+
+    df = evals_df(
+        logs_info,
+        columns=[
+            EvalColumn(path="eval.model", name="model"),
+            EvalColumn(path="eval.task_args.n_best_of_n", name="n_best_of_n", type=int),
+        ]
+        + EvalScores,
+    )
+
+    plot_performance(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/unexploitable_search/settings/alpaca/tasks.py
+++ b/src/unexploitable_search/settings/alpaca/tasks.py
@@ -19,6 +19,8 @@ def alpaca_benign(
     temperature: float = 1.0,
     side_quest_args: dict[str, Any] = {},
     grader_model: str = "openrouter/openai/gpt-5-nano",
+    score_side_quests: bool = False,
+    n_best_of_n: int = 1,
 ):
     # TODO decursify this
     if "word" not in side_quest_args:
@@ -26,22 +28,26 @@ def alpaca_benign(
     if "num_chars" not in side_quest_args:
         side_quest_args["num_chars"] = 100
 
-    scorers = [
-        side_quest_correctness(
-            side_quest=side_quest,
-            side_quest_args=side_quest_args,
-            grader_model=grader_model,
-        )
-        for side_quest in ALPACA_SIDE_QUESTS.values()
-    ]
-    scorers.append(alpaca_correctness(grader_model=grader_model))
+    scorers = [alpaca_correctness(grader_model=grader_model)]
+    if score_side_quests:
+        scorers += [
+            side_quest_correctness(
+                side_quest=side_quest,
+                side_quest_args=side_quest_args,
+                grader_model=grader_model,
+            )
+            for side_quest in ALPACA_SIDE_QUESTS.values()
+        ]
+
+    solver = generate(temperature=temperature)
+
+    if n_best_of_n > 1:
+        solver = best_of_n(n=n_best_of_n, solver=solver)
 
     return Task(
         dataset=dataset,
-        solver=[
-            generate(temperature=temperature),
-        ],
         scorer=scorers,
+        solver=solver,
     )
 
 

--- a/src/unexploitable_search/settings/apps/tasks.py
+++ b/src/unexploitable_search/settings/apps/tasks.py
@@ -1,5 +1,5 @@
 from inspect_ai import Task, task
-from inspect_ai.solver import generate, system_message
+from inspect_ai.solver import chain, generate, system_message
 
 from unexploitable_search.best_of_n.best_of_n import best_of_n
 from unexploitable_search.config.core import PACKAGE_ROOT
@@ -18,6 +18,8 @@ def apps_benign(
     two_step: bool = False,
     temperature: float = 1.0,
     name: str | None = None,
+    n_best_of_n: int = 1,
+    score_side_quests: bool = False,
 ):
     """
     APPS dataset task that generates and executes Python code to solve programming problems.
@@ -26,12 +28,15 @@ def apps_benign(
         run_id: Unique identifier for this run to make tasks distinct.
     """
 
-    solver = [system_message(VANILLA_SYSTEM_PROMPT), generate()]
+    solver = chain(system_message(VANILLA_SYSTEM_PROMPT), generate())
+    if n_best_of_n > 1:
+        solver = best_of_n(n=n_best_of_n, solver=solver)
 
     scorers = [apps_execution_scorer()]
 
-    for side_quest in APPS_SIDE_QUESTS.values():
-        scorers.append(side_quest_scorer(side_quest))
+    if score_side_quests:
+        for side_quest in APPS_SIDE_QUESTS.values():
+            scorers.append(side_quest_scorer(side_quest))
 
     compose_path = PACKAGE_ROOT / "settings" / "apps" / "docker" / "compose.yaml"
     return Task(


### PR DESCRIPTION
- added scripts I'm using to investigate the performance of the best-of-n solver
- added option _not_ to score side quests in the alpaca_benign and apps_benign tasks in service of this
- we can probably delete the scripts from the repo once the problem is fixed, but making side quests scorers optional in the benign tasks seems like good functionality to have anyway