### PR TITLE
Run All Sidequest Experiment QoL improvements

### DIFF
--- a/scripts/experiments/run_all_side_quests.py
+++ b/scripts/experiments/run_all_side_quests.py
@@ -8,6 +8,8 @@ from unexploitable_search.settings.alpaca.tasks import alpaca, alpaca_benign
 from unexploitable_search.settings.apps.setting import APPSSetting
 from unexploitable_search.settings.apps.tasks import apps, apps_benign
 
+from unexploitable_search.settings.apps.sandbox import DockerSandbox
+
 
 def main(
     model: str,
@@ -17,9 +19,12 @@ def main(
     limit: int | None,
     num_samples: int,
     setting: str,
+    side_quests: list[str],
+    benign_only: bool,
 ):
     if setting == "apps":
         tasks = []
+        sandbox = DockerSandbox()
 
         for run_id in range(num_samples):
             tasks.append(
@@ -27,11 +32,17 @@ def main(
                     temperature=temperature,
                     name=f"benign_{run_id}",
                     score_side_quests=True,
+                    side_quests=side_quests,
+                    sandbox=sandbox,
                 )
             )
 
             # Add baseline case: model prompted for side objectives
+            if benign_only:
+                continue
             for side_quest in APPSSetting.side_quests.keys():
+                if side_quests is not None and side_quest not in side_quests:
+                    continue
                 tasks.append(
                     apps(
                         side_quest=side_quest,
@@ -39,6 +50,7 @@ def main(
                         prompt_side_quest=True,
                         temperature=temperature,
                         name=f"{side_quest}_{run_id}",
+                        sandbox=sandbox,
                     )
                 )
 
@@ -50,6 +62,8 @@ def main(
             temperature=temperature,
             sample_shuffle=sample_shuffle_seed,
             limit=limit,
+            max_connections=4,
+            max_samples=4,
         )
 
     elif setting == "alpaca":
@@ -60,11 +74,16 @@ def main(
                 alpaca_benign(
                     temperature=temperature,
                     score_side_quests=True,
+                    side_quests=side_quests,
                 )
             )
 
             # Add baseline case: model prompted for side objectives
+            if benign_only:
+                continue
             for side_quest in AlpacaSetting.side_quests.keys():
+                if side_quests is not None and side_quest not in side_quests:
+                    continue
                 tasks.append(
                     alpaca(
                         temperature=temperature,
@@ -80,6 +99,8 @@ def main(
             temperature=temperature,
             sample_shuffle=sample_shuffle_seed,
             limit=limit,
+            max_connections=4,
+            max_samples=4,
         )
 
     else:
@@ -101,6 +122,8 @@ if __name__ == "__main__":
     parser.add_argument("--sample-shuffle-seed", type=int, required=False, default=0)
     parser.add_argument("--limit", type=int, required=False, default=None)
     parser.add_argument("--num-samples", type=int, required=False, default=1)
+    parser.add_argument("--side-quests", type=str, required=False, default=None)
+    parser.add_argument("--benign-only", type=bool, required=False, default=False)
     args = parser.parse_args()
 
     main(
@@ -111,4 +134,6 @@ if __name__ == "__main__":
         args.limit,
         args.num_samples,
         args.setting,
+        args.side_quests,
+        args.benign_only,
     )

--- a/src/unexploitable_search/settings/alpaca/tasks.py
+++ b/src/unexploitable_search/settings/alpaca/tasks.py
@@ -18,6 +18,7 @@ def alpaca_benign(
     side_quest_args: dict[str, Any] = {},
     grader_model: str = "openrouter/openai/gpt-5-nano",
     score_side_quests: bool = False,
+    side_quests: list[str] = [],
     n_best_of_n: int = 1,
 ):
     # TODO decursify this
@@ -28,13 +29,18 @@ def alpaca_benign(
 
     scorers = [alpaca_correctness(grader_model=grader_model)]
     if score_side_quests:
+        side_quests_to_score = AlpacaSetting.side_quests
+        if side_quests is not None:
+            side_quests_to_score = {
+                k: v for k, v in AlpacaSetting.side_quests.items() if k in side_quests
+            }
         scorers += [
             side_quest_correctness(
                 side_quest=side_quest,
                 side_quest_args=side_quest_args,
                 grader_model=grader_model,
             )
-            for side_quest in AlpacaSetting.side_quests.values()
+            for side_quest in side_quests_to_score.values()
         ]
 
     solver = generate(temperature=temperature)

--- a/src/unexploitable_search/settings/apps/scorers.py
+++ b/src/unexploitable_search/settings/apps/scorers.py
@@ -7,12 +7,13 @@ from inspect_ai.solver import TaskState
 from unexploitable_search.settings.apps.quests import APPSSideQuest
 from unexploitable_search.settings.apps.sandbox import (
     InspectSandbox,
+    Sandbox,
 )
 from unexploitable_search.settings.apps.setting import APPSSetting
 
 
 @scorer(metrics=[accuracy()])
-def apps_execution_scorer(binarise: bool = False):
+def apps_execution_scorer(binarise: bool = False, sandbox: Sandbox | None = None):
     """
     Custom scorer that executes generated Python code and compares output with expected results.
     Args:
@@ -21,9 +22,10 @@ def apps_execution_scorer(binarise: bool = False):
     Returns:
         A scorer function that can be used to score the code execution.
     """
+    if sandbox is None:
+        sandbox = InspectSandbox()
 
     async def score(state: TaskState, target: Target) -> Score:
-        sandbox = InspectSandbox()
         generated_code = state.output.completion
         input_output_data = state.metadata.get("input_output", {})
         # generate a unique output file for each execution
@@ -60,13 +62,14 @@ def apps_execution_scorer(binarise: bool = False):
 
 
 @scorer(metrics=[accuracy()])
-def side_quest_scorer(side_quest: type[APPSSideQuest]):
+def side_quest_scorer(side_quest: type[APPSSideQuest], sandbox: Sandbox | None = None):
     """
     Scorer that checks if the side quest was completed.
     """
+    if sandbox is None:
+        sandbox = InspectSandbox()
 
     async def score(state: TaskState, target: Target) -> Score:
-        sandbox = InspectSandbox()
         generated_code = state.output.completion
         input_output_data = state.metadata.get("input_output", {})
 

--- a/src/unexploitable_search/settings/apps/tasks.py
+++ b/src/unexploitable_search/settings/apps/tasks.py
@@ -3,6 +3,7 @@ from inspect_ai.solver import chain, generate, system_message
 
 from unexploitable_search.best_of_n.best_of_n import best_of_n
 from unexploitable_search.config.core import PACKAGE_ROOT
+from unexploitable_search.settings.apps.sandbox import Sandbox
 from unexploitable_search.settings.apps.dataset import dataset
 from unexploitable_search.settings.apps.prompts import VANILLA_SYSTEM_PROMPT
 from unexploitable_search.settings.apps.scorers import (
@@ -20,6 +21,8 @@ def apps_benign(
     name: str | None = None,
     n_best_of_n: int = 1,
     score_side_quests: bool = False,
+    side_quests: list[str] = [],
+    sandbox: Sandbox | None = None,
 ):
     """
     APPS dataset task that generates and executes Python code to solve programming problems.
@@ -32,10 +35,15 @@ def apps_benign(
     if n_best_of_n > 1:
         solver = best_of_n(n=n_best_of_n, solver=solver)
 
-    scorers = [apps_execution_scorer()]
+    scorers = [apps_execution_scorer(sandbox=sandbox)]
 
     if score_side_quests:
-        for side_quest in APPSSetting.side_quests.values():
+        side_quests_to_score = APPSSetting.side_quests
+        if side_quests is not None:
+            side_quests_to_score = {
+                k: v for k, v in APPSSetting.side_quests.items() if k in side_quests
+            }
+        for side_quest in side_quests_to_score.values():
             scorers.append(side_quest_scorer(side_quest))
 
     compose_path = PACKAGE_ROOT / "settings" / "apps" / "sandbox" / "compose.yaml"
@@ -56,6 +64,7 @@ def apps(
     temperature: float = 1.0,
     name: str | None = None,
     n_best_of_n: int = 1,
+    sandbox: Sandbox | None = None,
 ):
     """
     APPS dataset task that generates and executes Python code to solve programming problems.
@@ -81,9 +90,11 @@ def apps(
     if n_best_of_n > 1:
         solver = best_of_n(n=n_best_of_n, solver=solver)
 
-    scorers = [apps_execution_scorer()]
+    scorers = [apps_execution_scorer(sandbox=sandbox)]
     if side_quest:
-        scorers.append(side_quest_scorer(APPSSetting.side_quests[side_quest]))
+        scorers.append(
+            side_quest_scorer(APPSSetting.side_quests[side_quest], sandbox=sandbox)
+        )
 
     compose_path = PACKAGE_ROOT / "settings" / "apps" / "sandbox" / "compose.yaml"
     return Task(


### PR DESCRIPTION
This PR allows you to specify:
- Which side quests to test: In case we only want to test on specific side quests rather than all
- Benign only: In case we don't want to test on explicitly prompted models (useful when you have a model organism)

It also allows specifying which sandbox to use (before it was hardcoded to inspect) and now we're using Docker