### PR TITLE
Implement Reward EMA for Checkpoint Saving

### DIFF
--- a/src/unexploitable_search/callbacks/best_reward.py
+++ b/src/unexploitable_search/callbacks/best_reward.py
@@ -11,9 +11,25 @@ from transformers import (
 
 
 class SaveBestRewardCallback(TrainerCallback):
-    def __init__(self, save_dir: str = "best_reward_ckpt"):
-        self.best_reward = float("-inf")
+    def __init__(self, save_dir: str = "best_reward_ckpt", ema_alpha: float = 0.1):
+        """
+        Initialize the callback with exponential moving average tracking.
+
+        Args:
+            save_dir: Directory to save the best model
+            ema_alpha: Smoothing factor for EMA (0 < alpha <= 1).
+                      Lower values give more weight to historical data,
+                      higher values give more weight to recent observations.
+        """
+        self.ema_reward = None  # Will be initialized on first reward
+        self.best_ema_reward = float("-inf")
         self.save_dir = save_dir
+        self.ema_alpha = ema_alpha
+
+        if not (0 < ema_alpha <= 1):
+            raise ValueError(
+                "ema_alpha must be between 0 and 1 (exclusive of 0, inclusive of 1)"
+            )
 
     def on_log(
         self,
@@ -26,11 +42,24 @@ class SaveBestRewardCallback(TrainerCallback):
         **kwargs: Dict[str, Any],
     ):
         if logs and "reward" in logs:
-            current = logs["reward"]
-            if current > self.best_reward:
-                self.best_reward = current
+            current_reward = logs["reward"]
+
+            # Initialize EMA with first reward value
+            if self.ema_reward is None:
+                self.ema_reward = current_reward
+            else:
+                # Update EMA: EMA_new = alpha * current + (1 - alpha) * EMA_old
+                self.ema_reward = (
+                    self.ema_alpha * current_reward
+                    + (1 - self.ema_alpha) * self.ema_reward
+                )
+
+            # Check if this is the best EMA reward we've seen
+            if self.ema_reward > self.best_ema_reward:
+                self.best_ema_reward = self.ema_reward
                 print(
-                    f"🔺 New best reward {current:.4f} at step {state.global_step}, saving model…"
+                    f"🔺 New best EMA reward {self.ema_reward:.4f} (current: {current_reward:.4f}) "
+                    f"at step {state.global_step}, saving model…"
                 )
                 log_model: PreTrainedModel = cast(PreTrainedModel, model)
                 log_model.save_pretrained(self.save_dir)


### PR DESCRIPTION
This PR converts the best model saving callback into a moving-average. Previous implementation would be greedy, saving a model if in that step it got a high score. This one will look at the Exponential Moving Average reward to determine if the model has been performing better than before