### PR TITLE
Handle keyboard interrupt during training for early stopping

### DIFF
--- a/src/unexploitable_search/mitigation_strats/train.py
+++ b/src/unexploitable_search/mitigation_strats/train.py
@@ -1,22 +1,22 @@
-import hydra
-import wandb
-from wandb.errors import CommError
 from pathlib import Path
+
+import hydra
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
-
-from transformers import AutoModelForCausalLM
 from peft import PeftModel, get_peft_model
+from transformers import AutoModelForCausalLM
+from trl.trainer.grpo_config import GRPOConfig
+from trl.trainer.grpo_trainer import GRPOTrainer
 
-from unexploitable_search.settings.apps.sandbox import DockerSandbox
+import wandb
 from unexploitable_search.callbacks.best_reward import SaveBestRewardCallback
 from unexploitable_search.config.core import PROJECT_ROOT
 from unexploitable_search.model_organisms.train_utils import (
     make_quest_grpo_reward,
 )
-from trl.trainer.grpo_config import GRPOConfig
-from trl.trainer.grpo_trainer import GRPOTrainer
+from unexploitable_search.settings.apps.sandbox import DockerSandbox
 from unexploitable_search.settings.apps.setting import APPSSetting
+from wandb.errors import CommError
 
 
 @hydra.main(
@@ -105,7 +105,10 @@ def main(cfg: DictConfig):
         callbacks=[SaveBestRewardCallback(save_dir=str(output_dir / "best_model"))],
     )
 
-    trainer.train()
+    try:
+        trainer.train()
+    except KeyboardInterrupt:
+        print("Keyboard interrupt detected. Finishing training.")
 
     # upload the final trained model organism to wandb for later use
     for model_dir in ["model", "best_model"]:

--- a/src/unexploitable_search/model_organisms/train.py
+++ b/src/unexploitable_search/model_organisms/train.py
@@ -53,7 +53,10 @@ def main(cfg: DictConfig):
         callbacks=[SaveBestRewardCallback(save_dir=str(output_dir / "best_model"))],
     )
 
-    trainer.train()
+    try:
+        trainer.train()
+    except KeyboardInterrupt:
+        print("Keyboard interrupt detected. Finishing training.")
 
     # upload the final trained model organism to wandb for later use
     for model_dir in ["model", "best_model"]:


### PR DESCRIPTION
It is common for training runs with RL that either training has already converged a lot earlier than expected, or that training degrades to mode collapse after a period of stable improvements. This PR allows early stopping through keyboard interrupts, which will interrupt the training run, but allow the best and latest model to be pushed to wandb