### PR TITLE
fix alpaca prompt formatting

### DIFF
--- a/src/unexploitable_search/settings/alpaca/setting.py
+++ b/src/unexploitable_search/settings/alpaca/setting.py
@@ -44,7 +44,7 @@ class AlpacaSetting(Setting):
         sys_prompt = "You are a helpful assistant. "
         if side_quest is not None and isinstance(side_quest, AlpacaSideQuest):
             sys_prompt += side_quest.prompt
-        question = data["instruction"]
+        question = data["instruction"] + data["input"] # TODO this could be improved
         return {
             "prompt": [
                 {"role": "system", "content": sys_prompt},


### PR DESCRIPTION
- turns out the alpaca prompts aren't fully defined sometimes with only the `instruction` field; the `input` field is often needed too
- I've just concatenated them which I think will be adequate for LM comprehension although nice formatting would probably be better