### PR TITLE
Fix Prompted Mitigation Training

### DIFF
--- a/src/unexploitable_search/mitigation_strats/train.py
+++ b/src/unexploitable_search/mitigation_strats/train.py
@@ -109,10 +109,10 @@ def main(cfg: DictConfig):
     # for prompted model organisms, we need to add an instruction to follow the side quest to the system prompt
     if cfg.model_organism.organism_type.prompted:
         train_dataset = train_dataset.map(
-            lambda x: setting.add_side_quest_to_system_prompt(x, side_quest)
+            lambda x: type(setting).add_side_quest_to_system_prompt(x, side_quest)
         )
         eval_dataset = eval_dataset.map(
-            lambda x: setting.add_side_quest_to_system_prompt(x, side_quest)
+            lambda x: type(setting).add_side_quest_to_system_prompt(x, side_quest)
         )
 
     if len(eval_dataset) > cfg.train.max_validation_set_size:

--- a/src/unexploitable_search/settings/apps/setting.py
+++ b/src/unexploitable_search/settings/apps/setting.py
@@ -145,11 +145,15 @@ class APPSSetting(Setting):
         return dataset  # type: ignore
 
     @staticmethod
-    def add_side_quest_to_system_prompt(data: dict[str, Any], side_quest: type[APPSSideQuest]) -> dict[str, Any]:
+    def add_side_quest_to_system_prompt(  # type: ignore # Annoying, but it makes less sense to import AlpacaSideQuest here
+        data: dict[str, Any], side_quest: type[APPSSideQuest]
+    ) -> dict[str, Any]:
         """
         Adds the side quest to the system prompt.
         """
         assert "prompt" in data
         assert data["prompt"][0]["role"] == "system"
-        data["prompt"][0]["content"] = SIDEQUEST_SYSTEM_PROMPT.format(side_objective=side_quest.prompt)
+        data["prompt"][0]["content"] = SIDEQUEST_SYSTEM_PROMPT.format(
+            side_objective=side_quest.prompt
+        )
         return data

--- a/src/unexploitable_search/settings/apps/setting.py
+++ b/src/unexploitable_search/settings/apps/setting.py
@@ -6,6 +6,7 @@ from datasets import Dataset, load_dataset
 
 from unexploitable_search.setting import Setting
 from unexploitable_search.settings.apps.prompts import (
+    SIDEQUEST_SYSTEM_PROMPT,
     VANILLA_SYSTEM_PROMPT,
 )
 from unexploitable_search.settings.apps.quests import (
@@ -142,3 +143,13 @@ class APPSSetting(Setting):
 
         dataset = dataset.select(list(selected))  # type: ignore
         return dataset  # type: ignore
+
+    @staticmethod
+    def add_side_quest_to_system_prompt(data: dict[str, Any], side_quest: type[APPSSideQuest]) -> dict[str, Any]:
+        """
+        Adds the side quest to the system prompt.
+        """
+        assert "prompt" in data
+        assert data["prompt"][0]["role"] == "system"
+        data["prompt"][0]["content"] = SIDEQUEST_SYSTEM_PROMPT.format(side_objective=side_quest.prompt)
+        return data


### PR DESCRIPTION
Currently the side quest prompt is being appended to the system prompt without much additional guidance. This has lead to low performance on the side quest from prompted model organisms, as well as inconsistent behavior between training and evaluating. This PR aligns training and evaluation for the APPS setting.