### PR TITLE
Fix Alice's generate function overriding adapter recovery

### DIFF
--- a/src/unexploitable_search/mitigation_strats/two_player/alice.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/alice.py
@@ -99,8 +99,6 @@ class Alice(Player):
         **gen_kwargs: Any,
     ) -> List[str]:
         # add wandb_path adapter to model
-        if not self.is_prompted and self.wandb_path is not None:
-            self.model.set_adapter(adapter_name=self.adapter_name)
 
         completions = super().generate(prompts, deduplicate, **gen_kwargs)
         completions = [clean_generated_code(completion) for completion in completions]

--- a/src/unexploitable_search/mitigation_strats/two_player/player.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/player.py
@@ -133,7 +133,7 @@ class Player(ABC):
 
         # Save current state
         # It's always a list of one element
-        previous_adapter = self.model.active_adapters[0]
+        previous_adapter = self.model.active_adapter
         was_training = self.model.training
 
         # Set this player's adapter as active


### PR DESCRIPTION
The player's `generate` function handles adapter statefulness by keeping track of the previously active adapter and re-setting it after generation is done. Alice's function had an override that affected this procedure, effectively losing the previous active adapter. This PR removes that override. Training should still work for prompted and trained model organisms