### PR TITLE
Compute reward shaping for all steps

### DIFF
--- a/src/unexploitable_search/mitigation_strats/two_player/game_trainer.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/game_trainer.py
@@ -422,7 +422,6 @@ class GameTrainer:
                 rewards[i] = cast(float, rewards[i]) - score_val
             else:
                 rewards[i] = cast(float, rewards[i]) + score_val
-                continue
 
             # Implemented a solution which has a removable property
             if bob_flagged:


### PR DESCRIPTION
If Alice was not flagged, reward nuggets would not be added. this would prevent Bob to learn from examples if Charlie fails proposing good properties. This PR removes this, computing reward nuggets for all steps regardless of their outcome.