### PR TITLE
Set Gemma's correct pad/eos token

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
     - id: pyright
       name: pyright
-      stages: [pre-commit]
+      stages: [commit]
       types: [python]
       entry: uv run pyright
       language: system

--- a/conf/_shared/base_model/gemma3_4b.yaml
+++ b/conf/_shared/base_model/gemma3_4b.yaml
@@ -1,2 +1,4 @@
 short: gemma3_4b
 hf_path: google/gemma-3-4b-it
+eos_token_id: 106  # <end_of_turn> for Gemma
+pad_token_id: 106

--- a/src/unexploitable_search/mitigation_strats/strats/length_penalty.py
+++ b/src/unexploitable_search/mitigation_strats/strats/length_penalty.py
@@ -1,17 +1,25 @@
 from typing import Any, Callable
 
+from transformers import PreTrainedTokenizer
 
-def make_length_penalty_reward_func(length_penalty_coefficient: float) -> Callable:  # type: ignore
+
+def make_length_penalty_reward_func(  # type: ignore
+    length_penalty_coefficient: float, processing_class: PreTrainedTokenizer
+) -> Callable:
     def length_penalty_reward_func(
         prompts: list[list[dict[str, str]]],
         completions: list[list[dict[str, str]]],
         completion_ids: list[list[int]],
         **kwargs: Any,
     ) -> list[float]:
-        # completion ids is a list of the token ids for each completion
-        # each reward should be of the form: -alpha * total_number_of_tokens
+        # Completion ids do not reliably remove all special tokens
+        # e.g. gemma outputs the <end_of_turn> token, which is not the eos or pad token
+        # Best is to encode the completions back into tokens
+        completions_content = [completion[0]["content"] for completion in completions]
+        completion_ids = processing_class.batch_encode_plus(completions_content)['input_ids']  # type: ignore
+        
         rewards = [
-            -length_penalty_coefficient * len(token_ids) for token_ids in completion_ids
+            -length_penalty_coefficient * len(tokens) for tokens in completion_ids
         ]
 
         return rewards

--- a/src/unexploitable_search/mitigation_strats/strats/length_penalty.py
+++ b/src/unexploitable_search/mitigation_strats/strats/length_penalty.py
@@ -21,7 +21,7 @@ def make_length_penalty_reward_func(  # type: ignore
         )["input_ids"]  # type: ignore
 
         rewards = [
-            -length_penalty_coefficient * len(tokens) for tokens in completion_ids
+            -length_penalty_coefficient * len(token_ids) for token_idss in completion_ids
         ]
 
         return rewards

--- a/src/unexploitable_search/mitigation_strats/strats/length_penalty.py
+++ b/src/unexploitable_search/mitigation_strats/strats/length_penalty.py
@@ -12,14 +12,6 @@ def make_length_penalty_reward_func(  # type: ignore
         completion_ids: list[list[int]],
         **kwargs: Any,
     ) -> list[float]:
-        # Completion ids do not reliably remove all special tokens
-        # e.g. gemma outputs the <end_of_turn> token, which is not the eos or pad token
-        # Best is to encode the completions back into tokens
-        completions_content = [completion[0]["content"] for completion in completions]
-        completion_ids = processing_class(
-            completions_content, add_special_tokens=False
-        )["input_ids"]  # type: ignore
-
         rewards = [
             -length_penalty_coefficient * len(token_ids) for token_ids in completion_ids
         ]

--- a/src/unexploitable_search/mitigation_strats/strats/length_penalty.py
+++ b/src/unexploitable_search/mitigation_strats/strats/length_penalty.py
@@ -21,7 +21,7 @@ def make_length_penalty_reward_func(  # type: ignore
         )["input_ids"]  # type: ignore
 
         rewards = [
-            -length_penalty_coefficient * len(token_ids) for token_idss in completion_ids
+            -length_penalty_coefficient * len(token_ids) for token_ids in completion_ids
         ]
 
         return rewards

--- a/src/unexploitable_search/mitigation_strats/strats/length_penalty.py
+++ b/src/unexploitable_search/mitigation_strats/strats/length_penalty.py
@@ -16,8 +16,10 @@ def make_length_penalty_reward_func(  # type: ignore
         # e.g. gemma outputs the <end_of_turn> token, which is not the eos or pad token
         # Best is to encode the completions back into tokens
         completions_content = [completion[0]["content"] for completion in completions]
-        completion_ids = processing_class.batch_encode_plus(completions_content)['input_ids']  # type: ignore
-        
+        completion_ids = processing_class(
+            completions_content, add_special_tokens=False
+        )["input_ids"]  # type: ignore
+
         rewards = [
             -length_penalty_coefficient * len(tokens) for tokens in completion_ids
         ]

--- a/src/unexploitable_search/mitigation_strats/train.py
+++ b/src/unexploitable_search/mitigation_strats/train.py
@@ -17,6 +17,7 @@ from unexploitable_search.mitigation_strats.strats.length_penalty import (
 from unexploitable_search.settings.apps.sandbox import DockerSandbox
 from unexploitable_search.settings.apps.setting import APPSSetting
 from unexploitable_search.train_utils import (
+    configure_tokenizer_tokens,
     log_artifact_with_retries,
     make_quest_grpo_reward,
     save_dataset_as_wandb_artifact,
@@ -90,6 +91,7 @@ def main(cfg: DictConfig):
 
     # Load and configure tokenizer
     tokenizer = AutoTokenizer.from_pretrained(cfg.model_organism.base_model.hf_path)
+    configure_tokenizer_tokens(tokenizer, cfg.model_organism.base_model)
 
     wandb.init(
         project=cfg.project,

--- a/src/unexploitable_search/mitigation_strats/train.py
+++ b/src/unexploitable_search/mitigation_strats/train.py
@@ -90,7 +90,7 @@ def main(cfg: DictConfig):
 
     # Load and configure tokenizer
     tokenizer = AutoTokenizer.from_pretrained(cfg.model_organism.base_model.hf_path)
-    
+
     wandb.init(
         project=cfg.project,
         name=cfg.run_name,

--- a/src/unexploitable_search/mitigation_strats/train.py
+++ b/src/unexploitable_search/mitigation_strats/train.py
@@ -6,7 +6,7 @@ import torch
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 from peft import PeftMixedModel, PeftModel, get_peft_model
-from transformers import AutoModelForCausalLM
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import wandb
 from unexploitable_search.callbacks.best_reward import SaveBestRewardCallback
@@ -88,6 +88,9 @@ def get_model_organism(cfg: DictConfig):  # type: ignore
 def main(cfg: DictConfig):
     model_organism = get_model_organism(cfg)
 
+    # Load and configure tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(cfg.model_organism.base_model.hf_path)
+    
     wandb.init(
         project=cfg.project,
         name=cfg.run_name,
@@ -143,7 +146,8 @@ def main(cfg: DictConfig):
     if cfg.strat.name == "length_penalty":
         # create a length penalty reward function and append it to reward_funcs
         length_penalty_reward_func = make_length_penalty_reward_func(
-            cfg.strat.length_penalty_coefficient
+            cfg.strat.length_penalty_coefficient,
+            processing_class=tokenizer,
         )
         reward_funcs.append(length_penalty_reward_func)
 
@@ -153,6 +157,7 @@ def main(cfg: DictConfig):
     output_dir = Path(cfg.train.trl_trainer_config.output_dir)
     trainer = MaxEntGRPOTrainer(
         model=model_organism,  # type: ignore
+        processing_class=tokenizer,  # type: ignore
         reward_funcs=reward_funcs,  # type: ignore
         args=args,  # type: ignore
         train_dataset=train_dataset,  # type: ignore

--- a/src/unexploitable_search/mitigation_strats/train_two_player.py
+++ b/src/unexploitable_search/mitigation_strats/train_two_player.py
@@ -15,6 +15,7 @@ from unexploitable_search.mitigation_strats.two_player.property_checkers import 
     LocalChecker,
 )
 from unexploitable_search.train_utils import (
+    configure_tokenizer_tokens,
     log_artifact_with_retries,
     save_dataset_as_wandb_artifact,
 )
@@ -68,6 +69,7 @@ def main(cfg: DictConfig):
     tokenizer = AutoTokenizer.from_pretrained(
         cfg.model_organism.base_model.hf_path, padding_side="left"
     )
+    configure_tokenizer_tokens(tokenizer, cfg.model_organism.base_model)
 
     if not cfg.model_organism.organism_type.prompted:
         if "wandb_artifact_path" in cfg.model_organism:

--- a/src/unexploitable_search/train_utils.py
+++ b/src/unexploitable_search/train_utils.py
@@ -192,3 +192,26 @@ def named(name: str) -> Callable[[Any], Any]:
         return func
 
     return decorator
+
+
+def configure_tokenizer_tokens(tokenizer: Any, base_model_cfg: Any) -> None:
+    """
+    Configure tokenizer token IDs from the base model config if specified.
+
+    This function checks if eos_token_id and pad_token_id are specified in the
+    base_model config and sets them on the tokenizer if present. This is useful
+    for models like Gemma that require specific token configurations.
+
+    Args:
+        tokenizer: The tokenizer instance to configure
+        base_model_cfg: The base model config from hydra (e.g., cfg.base_model
+                       or cfg.model_organism.base_model)
+
+    Example:
+        tokenizer = AutoTokenizer.from_pretrained(cfg.base_model.hf_path)
+        configure_tokenizer_tokens(tokenizer, cfg.base_model)
+    """
+    if hasattr(base_model_cfg, "eos_token_id"):
+        tokenizer.eos_token_id = base_model_cfg.eos_token_id
+    if hasattr(base_model_cfg, "pad_token_id"):
+        tokenizer.pad_token_id = base_model_cfg.pad_token_id


### PR DESCRIPTION
This PR adds necessary logic to set pad/eos token based on base model. This fixes generation time issues with gemma, as well as length computation for length penalty