### PR TITLE
Add generation caching. Fix not cleaning code when training

### DIFF
--- a/conf/mitigation_strats/strat/two_player.yaml
+++ b/conf/mitigation_strats/strat/two_player.yaml
@@ -2,7 +2,7 @@ name: two_player
 tokenizer: meta-llama/Llama-3.1-8B-Instruct
 num_cycles: 50
 steps_per_cycle: 10
-training_order: ["charlie", "bob", "alice"]
+training_order: ["alice", "charlie", "bob"]
 logging_steps: 10  # Enable logging every 10 steps
 log_completions: True # Enable completion logging to wandb
 two_player_coefficient: 0.2

--- a/src/unexploitable_search/mitigation_strats/train.py
+++ b/src/unexploitable_search/mitigation_strats/train.py
@@ -1,4 +1,5 @@
 import re
+import tempfile
 from pathlib import Path
 
 import hydra
@@ -44,7 +45,8 @@ def get_model_organism(cfg: DictConfig):  # type: ignore
     elif "wandb_artifact_path" in cfg.model_organism:
         print("Downloading model organism from W&B...")
         artifact = api.artifact(cfg.model_organism.wandb_artifact_path)
-        path = artifact.download(root="./downloaded_model")
+        temp_dir = tempfile.mkdtemp()
+        path = artifact.download(root=temp_dir)
         # the vanilla LM
         base_model = AutoModelForCausalLM.from_pretrained(
             cfg.model_organism.base_model.hf_path, torch_dtype=torch.bfloat16

--- a/src/unexploitable_search/mitigation_strats/train_two_player.py
+++ b/src/unexploitable_search/mitigation_strats/train_two_player.py
@@ -83,12 +83,6 @@ def main(cfg: DictConfig):
     else:
         wandb_path = None
 
-    # Load property checker
-    property_checker = LocalChecker(
-        model=base_model,
-        tokenizer=tokenizer,
-    )
-
     # Create coordinator
     output_dir = Path(cfg.train.trl_trainer_config.output_dir)
     # Calculate total training steps for proper learning rate annealing
@@ -103,7 +97,6 @@ def main(cfg: DictConfig):
         eval_dataset=validation_dataset,
         setting=setting,
         output_dir=output_dir,
-        property_checker=property_checker,
         reward_coeff=cfg.strat.two_player_coefficient,
         best_of=cfg.strat.best_of,
         total_steps=total_steps,

--- a/src/unexploitable_search/mitigation_strats/train_two_player.py
+++ b/src/unexploitable_search/mitigation_strats/train_two_player.py
@@ -1,4 +1,5 @@
 import re
+import tempfile
 import traceback
 from pathlib import Path
 
@@ -75,7 +76,8 @@ def main(cfg: DictConfig):
         if "wandb_artifact_path" in cfg.model_organism:
             api = wandb.Api()
             artifact = api.artifact(cfg.model_organism.wandb_artifact_path)
-            wandb_path = artifact.download(root="./downloaded_model")
+            temp_dir = tempfile.mkdtemp()
+            wandb_path = artifact.download(root=temp_dir)
         else:
             raise ValueError(
                 "model_organism must specify a wandb_artifact_path for non-prompted model organisms"

--- a/src/unexploitable_search/mitigation_strats/two_player/alice.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/alice.py
@@ -97,11 +97,15 @@ class Alice(Player):
         self,
         prompts: list[Dict[str, Any]],
         deduplicate: bool = False,
+        identifier: str | None = None,
+        cache: bool = True,
         **gen_kwargs: Any,
     ) -> List[str]:
         # add wandb_path adapter to model
 
-        completions = super().generate(prompts, deduplicate, **gen_kwargs)
+        completions = super().generate(
+            prompts, deduplicate, identifier, cache, **gen_kwargs
+        )
         completions = [clean_generated_code(completion) for completion in completions]
         return completions
 
@@ -119,7 +123,13 @@ class Alice(Player):
         3. If Alice violates property, Bob tries to fix
         4. Compute Alice's reward
         """
-        a_completions = [completion[0]["content"] for completion in completions]
+        a_completions = [
+            clean_generated_code(completion[0]["content"]) for completion in completions
+        ]
+        # Set cache for alice's generation
+        identifier = hash(str(prompts))
+        self.cache[identifier] = a_completions  # type: ignore
+
         # Get other players
         rewards, *_ = asyncio.run(
             self.game_fn(

--- a/src/unexploitable_search/mitigation_strats/two_player/alice.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/alice.py
@@ -127,7 +127,7 @@ class Alice(Player):
             clean_generated_code(completion[0]["content"]) for completion in completions
         ]
         # Set cache for alice's generation
-        identifier = hash(str(prompts))
+        identifier = f"{hash(str(prompts))}_true"
         self.cache[identifier] = a_completions  # type: ignore
 
         # Get other players

--- a/src/unexploitable_search/mitigation_strats/two_player/bob.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/bob.py
@@ -73,9 +73,13 @@ class Bob(Player):
         self,
         prompts: list[Dict[str, Any]],
         deduplicate: bool = False,
+        identifier: str | None = None,
+        cache: bool = True,
         **gen_kwargs: Any,
     ) -> List[str]:
-        completions = super().generate(prompts, deduplicate, **gen_kwargs)
+        completions = super().generate(
+            prompts, deduplicate, identifier, cache, **gen_kwargs
+        )
         completions = [clean_generated_code(completion) for completion in completions]
         return completions
 
@@ -95,10 +99,15 @@ class Bob(Player):
         c_completions = [
             self.extract_property(prompt[0]["content"]) for prompt in prompts
         ]
-
         a_completions = kwargs["alice_solutions"]
 
-        b_completions = [completion[0]["content"] for completion in completions]
+        b_completions = [
+            clean_generated_code(completion[0]["content"]) for completion in completions
+        ]
+        # Set cache for bob's generation
+        identifier = hash(str(prompts))
+        self.cache[identifier] = b_completions
+
         rewards, *_ = asyncio.run(
             self.game_fn(
                 a_completions=a_completions,

--- a/src/unexploitable_search/mitigation_strats/two_player/bob.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/bob.py
@@ -105,7 +105,7 @@ class Bob(Player):
             clean_generated_code(completion[0]["content"]) for completion in completions
         ]
         # Set cache for bob's generation
-        identifier = hash(str(prompts))
+        identifier = f"{hash(str(prompts))}_false"
         self.cache[identifier] = b_completions
 
         rewards, *_ = asyncio.run(

--- a/src/unexploitable_search/mitigation_strats/two_player/charlie.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/charlie.py
@@ -106,7 +106,7 @@ class Charlie(Player):
         ]
 
         # Set cache for charlie's generation
-        identifier = hash(str(prompts))
+        identifier = f"{hash(str(prompts))}_false"
         self.cache[identifier] = c_completions
 
         alice_solutions = kwargs["alice_solutions"]

--- a/src/unexploitable_search/mitigation_strats/two_player/charlie.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/charlie.py
@@ -34,10 +34,13 @@ class Charlie(Player):
                 deduplicate=True,
             )
 
+        hash_str = hash(str(alice_batch["prompt"]))
+
         # Generate reference solutions
         reference_solutions = self.alice.generate(
             alice_batch["prompt"],
             deduplicate=True,
+            identifier=f"alice_reference_solutions_{hash_str}",
         )
 
         questions = examples["question"]
@@ -65,9 +68,13 @@ class Charlie(Player):
         self,
         prompts: list[Dict[str, Any]],
         deduplicate: bool = False,
+        identifier: str | None = None,
+        cache: bool = True,
         **gen_kwargs: Any,
     ) -> List[str]:
-        completions = super().generate(prompts, deduplicate, **gen_kwargs)
+        completions = super().generate(
+            prompts, deduplicate, identifier, cache, **gen_kwargs
+        )
         return [self.extract_property(completion) for completion in completions]
 
     def extract_property(self, response: str) -> str:
@@ -97,6 +104,11 @@ class Charlie(Player):
             self.extract_property(completion[0]["content"])
             for completion in completions
         ]
+
+        # Set cache for charlie's generation
+        identifier = hash(str(prompts))
+        self.cache[identifier] = c_completions
+
         alice_solutions = kwargs["alice_solutions"]
         rewards, *_ = asyncio.run(
             self.game_fn(

--- a/src/unexploitable_search/mitigation_strats/two_player/game_trainer.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/game_trainer.py
@@ -204,6 +204,11 @@ class GameTrainer:
             print(f"Cycle {cycle + 1}/{num_cycles}")
             print(f"{'=' * 50}")
 
+            # Clear all caches
+            for player_name in training_order:
+                player = self.players[player_name]
+                player.clear_cache()
+
             for player_name in training_order:
                 player = self.players[player_name]
                 print(f"\nTraining {player_name.capitalize()}...")

--- a/src/unexploitable_search/mitigation_strats/two_player/game_trainer.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/game_trainer.py
@@ -370,7 +370,10 @@ class GameTrainer:
                 bob_scores[i],
                 rewards[i],
             )
-        wandb.log({"game_table": table})
+        try:
+            wandb.log({"game_table": table})
+        except wandb.errors.AuthenticationError:  # type: ignore
+            print("Authentication error when logging game table. Skipping.")
         return (
             [cast(float, reward) * self.reward_coeff for reward in rewards],
             has_properties_alice,

--- a/src/unexploitable_search/mitigation_strats/two_player/player.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/player.py
@@ -39,6 +39,7 @@ class Player(ABC):
         self.total_steps = (
             total_steps  # Total expected training steps for proper LR annealing
         )
+        self._cache: Dict[int | str, Any] = {}
 
     def set_model_params(
         self,
@@ -113,6 +114,8 @@ class Player(ABC):
         self,
         prompts: list[Dict[str, Any]],
         deduplicate: bool = False,
+        identifier: str | None = None,
+        cache: bool = True,
         **gen_kwargs: Any,
     ) -> List[str]:
         """
@@ -123,10 +126,18 @@ class Player(ABC):
             deduplicate: If True, deduplicate prompts by content hash and map responses back
             **gen_kwargs: Additional generation parameters
         """
+        # First try to fetch from cache
+        identifier = identifier or hash(str(prompts))  # type: ignore
+        if cache and identifier in self.cache:
+            return self.cache[identifier]
+
         if deduplicate:
-            return self._generate_with_deduplication(prompts, **gen_kwargs)
+            completions = self._generate_with_deduplication(prompts, **gen_kwargs)
         else:
-            return self._generate_direct(prompts, **gen_kwargs)
+            completions = self._generate_direct(prompts, **gen_kwargs)
+
+        self.cache[identifier] = completions  # type: ignore
+        return completions
 
     def _generate_direct(
         self, prompts: list[Dict[str, Any]], **gen_kwargs: Any
@@ -272,3 +283,10 @@ class Player(ABC):
 
         # Save only this player's adapter
         self.model.save_pretrained(path, selected_adapters=[self.adapter_name])
+
+    @property
+    def cache(self) -> Dict[str | int, Any]:
+        return self._cache
+
+    def clear_cache(self):
+        self._cache = {}

--- a/src/unexploitable_search/mitigation_strats/two_player/player.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/player.py
@@ -127,7 +127,8 @@ class Player(ABC):
             **gen_kwargs: Additional generation parameters
         """
         # First try to fetch from cache
-        identifier = identifier or hash(str(prompts))  # type: ignore
+        prompts_hash = hash(str(prompts))
+        identifier = identifier or f"{prompts_hash}_{deduplicate}"
         if cache and identifier in self.cache:
             return self.cache[identifier]
 

--- a/src/unexploitable_search/mitigation_strats/two_player/property_checkers/local_checker.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/property_checkers/local_checker.py
@@ -49,7 +49,7 @@ class LocalChecker(PropertyChecker):
             List of booleans indicating whether each solution has the corresponding property
         """
         # Get currently active adapter
-        active_adapter = self.model.active_adapter
+        active_adapter = self.model.active_adapters()[0]
 
         self.model.disasable_adapters()
 

--- a/src/unexploitable_search/mitigation_strats/two_player/property_checkers/local_checker.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/property_checkers/local_checker.py
@@ -51,7 +51,7 @@ class LocalChecker(PropertyChecker):
         # Get currently active adapter
         active_adapter = self.model.active_adapter
 
-        self.model.disable_adapters()
+        self.model.set_adapter("default")
 
         # Create chat format prompts for each solution/property pair
         chat_prompts = []

--- a/src/unexploitable_search/mitigation_strats/two_player/property_checkers/local_checker.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/property_checkers/local_checker.py
@@ -49,7 +49,7 @@ class LocalChecker(PropertyChecker):
             List of booleans indicating whether each solution has the corresponding property
         """
         # Get currently active adapter
-        active_adapter = self.model.active_adapters()[0]
+        active_adapter = self.model.active_adapter
 
         self.model.disasable_adapters()
 

--- a/src/unexploitable_search/mitigation_strats/two_player/property_checkers/local_checker.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/property_checkers/local_checker.py
@@ -51,7 +51,7 @@ class LocalChecker(PropertyChecker):
         # Get currently active adapter
         active_adapter = self.model.active_adapter
 
-        self.model.disasable_adapters()
+        self.model.disable_adapters()
 
         # Create chat format prompts for each solution/property pair
         chat_prompts = []

--- a/src/unexploitable_search/mitigation_strats/two_player/property_checkers/local_checker.py
+++ b/src/unexploitable_search/mitigation_strats/two_player/property_checkers/local_checker.py
@@ -48,6 +48,11 @@ class LocalChecker(PropertyChecker):
         Returns:
             List of booleans indicating whether each solution has the corresponding property
         """
+        # Get currently active adapter
+        active_adapter = self.model.active_adapter
+
+        self.model.disasable_adapters()
+
         # Create chat format prompts for each solution/property pair
         chat_prompts = []
         for solution, property_description in zip(solutions, property_descriptions):
@@ -104,5 +109,7 @@ class LocalChecker(PropertyChecker):
             else:
                 # Default to False if response is unclear
                 results.append(False)
+
+        self.model.set_adapter(active_adapter)
 
         return results


### PR DESCRIPTION
This PR aims to potentially fix a discrepancy happening later in training where All players would find winning strategies despite playing adversarially. The hypothesis is that Alice behaved differently during training vs when frozen. A discrepancy was found in the way we sanitize the outputs when in training, which could potentially lead to a strategy for Alice where she confuses the property checker writing outside the code boundaries.

Additionally, but equally important, this PR adds caching functionality, allowing later stages of training to reuse completions from previous players' training rounds, dramatically increasing training speed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce per-player generation caching with cycle-level resets, clean Alice/Bob completions in rewards, and change training order to ["alice","charlie","bob"].
> 
> - **Caching**:
>   - Add per-player generation cache in `Player` with `identifier`/`cache` params, defaulting to prompt-hash keys; expose `cache` property and `clear_cache()`.
>   - Use cache in `alice.generate`, `bob.generate`, `charlie.generate`; set cached completions in their `reward_func`s; clear all player caches at start of each cycle in `GameTrainer.train_cyclic`.
> - **Sanitization**:
>   - Clean Alice and Bob outputs via `clean_generated_code` in `generate` (and now also in their `reward_func`s for `a_completions`/`b_completions`).
> - **Charlie pipeline**:
>   - Add deterministic `identifier` for Alice reference solutions in `Charlie.transform_batch` (uses prompt hash).
> - **Config**:
>   - Update `conf/mitigation_strats/strat/two_player.yaml` `training_order` to `["alice", "charlie", "bob"]`.}
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4ce1ede097eb9eb5745719e8d02fd323a9b4fe8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->