### PR TITLE
make naming consistent for organism evals

### DIFF
--- a/conf/evals/_shared/inspect/inspect.yaml
+++ b/conf/evals/_shared/inspect/inspect.yaml
@@ -1,6 +1,6 @@
 epochs: 10
 limit: 100
-max_samples: 16
+max_samples: 4
 temperature: 0.6
 sandbox: podman
-sandbox_pool_size: 16
+sandbox_pool_size: 1

--- a/conf/evals/benign/config.yaml
+++ b/conf/evals/benign/config.yaml
@@ -17,4 +17,4 @@ side_quests_to_score:
   - logic_bomb
   - number_of_comments
 
-wandb_run: "benign-${hydra:runtime.choices.it_model}-${now:%m%d-%H%M}"
+run_name: "benign-eval-${hydra:runtime.choices.it_model}-${setting.name}-${now:%m%d-%H%M}"

--- a/conf/evals/mitigation/config.yaml
+++ b/conf/evals/mitigation/config.yaml
@@ -11,5 +11,7 @@ defaults:
   - _self_
 
 side_quest: ???
-
+seed: n/a
 wandb_artifact_path: ???
+
+run_name: "mitigation-eval-${hydra:runtime.choices.it_model}-${hydra:runtime.choices.model_organism}-${setting.name}-${side_quest}-${hydra:runtime.choices.strat}-s${seed}-${now:%m%d-%H%M}"

--- a/conf/evals/organism/config.yaml
+++ b/conf/evals/organism/config.yaml
@@ -13,3 +13,5 @@ defaults:
   - _self_
 
 side_quest: ???
+
+run_name: "organism-eval-${hydra:runtime.choices.it_model}-${hydra:runtime.choices.model_organism}-${setting.name}-${side_quest}-s${seed}-${now:%m%d-%H%M}"

--- a/conf/evals/organism/config.yaml
+++ b/conf/evals/organism/config.yaml
@@ -13,5 +13,6 @@ defaults:
   - _self_
 
 side_quest: ???
+seed: n/a
 
 run_name: "organism-eval-${hydra:runtime.choices.it_model}-${hydra:runtime.choices.model_organism}-${setting.name}-${side_quest}-s${seed}-${now:%m%d-%H%M}"

--- a/conf/model_organisms/config.yaml
+++ b/conf/model_organisms/config.yaml
@@ -15,7 +15,7 @@ side_quest: ???
 project: unexploitable-search
 seed: 42
 
-run_name: "organism-sft-${hydra:runtime.choices.it_model}-${setting.name}-${side_quest}-trained-s${seed}-${now:%m%d-%H%M}"
+run_name: "organism-sft-${hydra:runtime.choices.it_model}-trained-${setting.name}-${side_quest}-s${seed}-${now:%m%d-%H%M}"
 
 train:
   max_validation_set_size: 500

--- a/src/unexploitable_search/config/core.py
+++ b/src/unexploitable_search/config/core.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 PACKAGE_ROOT = Path(__file__).resolve().parent.parent
@@ -19,7 +20,12 @@ def get_data_dir() -> Path:
 
 
 def get_eval_dir() -> Path:
-    """Get the eval directory, creating it if it doesn't exist."""
-    eval_dir = PROJECT_ROOT / "eval"
-    eval_dir.mkdir(exist_ok=True)
+    """Get the eval directory, creating it if it doesn't exist.
+    Uses $SCRATCH/eval if SCRATCH is set (e.g., on cluster), otherwise uses PROJECT_ROOT/eval.
+    """
+    if "SCRATCH" in os.environ:
+        eval_dir = Path(os.environ["SCRATCH"]) / "eval"
+    else:
+        eval_dir = PROJECT_ROOT / "eval"
+    eval_dir.mkdir(parents=True, exist_ok=True)
     return eval_dir

--- a/src/unexploitable_search/eval/benign.py
+++ b/src/unexploitable_search/eval/benign.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import wandb
 from inspect_ai import eval
 from omegaconf import DictConfig, OmegaConf
@@ -18,10 +16,9 @@ def run_benign_eval(cfg: DictConfig):
     else:
         raise ValueError(f"Invalid setting: {cfg.setting}")
 
-    timestamp = datetime.now().strftime("%m%d-%H%M")
     run = wandb.init(
         project="unexploitable-search",
-        name=f"benign-{cfg.it_model.name}-{timestamp}",
+        name=cfg.run_name,
         config=OmegaConf.to_container(cfg, resolve=True),  # type: ignore
     )
     sandbox = get_sandbox_from_config(cfg)
@@ -37,7 +34,7 @@ def run_benign_eval(cfg: DictConfig):
         temperature=cfg.inspect.temperature,
     )
     # upload eval to wandb
-    artifact = wandb.Artifact(f"{cfg.wandb_run}-eval", type="eval")
+    artifact = wandb.Artifact(f"{cfg.run_name}-artifact", type="eval")
 
     if len(eval_log) > 1:
         print(f"Warning: Expected 1 eval log item, got {len(eval_log)}")

--- a/src/unexploitable_search/eval/mitigation.py
+++ b/src/unexploitable_search/eval/mitigation.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from pathlib import Path
 
@@ -39,7 +40,9 @@ def get_trained_model(cfg: DictConfig, mitigation_cfg: DictConfig) -> Path:
             cfg.it_model.hf_path, torch_dtype=torch.bfloat16
         )
         mitigation_artifact = api.artifact(cfg.wandb_artifact_path)
-        weights_dir = Path(tempfile.mkdtemp())
+        # Use TMPDIR if set (e.g., $SCRATCH/tmp on cluster), otherwise use system default
+        temp_dir = os.environ.get("TMPDIR", tempfile.gettempdir())
+        weights_dir = Path(tempfile.mkdtemp(dir=temp_dir))
         mitigation_lora_path = mitigation_artifact.download(
             root=weights_dir / "mitigation_lora"
         )
@@ -61,7 +64,9 @@ def get_trained_model(cfg: DictConfig, mitigation_cfg: DictConfig) -> Path:
         ) or OmegaConf.select(
             mitigation_cfg, "model_organism.value.wandb_artifact_path"
         )
-        weights_dir = Path(tempfile.mkdtemp())
+        # Use TMPDIR if set (e.g., $SCRATCH/tmp on cluster), otherwise use system default
+        temp_dir = os.environ.get("TMPDIR", tempfile.gettempdir())
+        weights_dir = Path(tempfile.mkdtemp(dir=temp_dir))
         try:
             model_organism_artifact = api.artifact(wandb_artifact_path)
         except ConfigAttributeError:

--- a/src/unexploitable_search/eval/mitigation.py
+++ b/src/unexploitable_search/eval/mitigation.py
@@ -10,7 +10,7 @@ from peft import PeftModel
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from unexploitable_search.config.core import get_eval_dir
-from unexploitable_search.eval.utils import get_sandbox_from_config, strip_path_and_tag
+from unexploitable_search.eval.utils import get_sandbox_from_config
 from unexploitable_search.settings.apps.eval.tasks import apps
 from unexploitable_search.wandb_utils import log_artifact_with_retries
 
@@ -114,7 +114,8 @@ def run_mitigation_eval(cfg: DictConfig):
 
     run = wandb.init(
         project="unexploitable-search",
-        name=f"{strip_path_and_tag(cfg.wandb_artifact_path)}-eval",
+        # name=f"{strip_path_and_tag(cfg.wandb_artifact_path)}-eval",
+        name=cfg.run_name,
         config=OmegaConf.to_container(cfg, resolve=True),  # type: ignore
     )
 
@@ -141,7 +142,9 @@ def run_mitigation_eval(cfg: DictConfig):
 
     # upload to wandb
     artifact = wandb.Artifact(
-        f"{strip_path_and_tag(cfg.wandb_artifact_path)}-eval", type="eval"
+        # f"{strip_path_and_tag(cfg.wandb_artifact_path)}-eval", type="eval"
+        f"{cfg.run_name}-artifact",
+        type="eval",
     )
 
     if len(eval_log) > 1:

--- a/src/unexploitable_search/eval/organism.py
+++ b/src/unexploitable_search/eval/organism.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from pathlib import Path
 
@@ -20,7 +21,9 @@ from unexploitable_search.wandb_utils import log_artifact_with_retries
 def get_trained_model(cfg: DictConfig) -> Path:
     api = wandb.Api()
     artifact = api.artifact(f"{cfg.model_organism.wandb_artifact_path}")
-    weights_dir = Path(tempfile.mkdtemp())
+    # Use TMPDIR if set (e.g., $SCRATCH/tmp on cluster), otherwise use system default
+    temp_dir = os.environ.get("TMPDIR", tempfile.gettempdir())
+    weights_dir = Path(tempfile.mkdtemp(dir=temp_dir))
     lora_path = artifact.download(root=weights_dir / "model_organism_lora")
     it_model = AutoModelForCausalLM.from_pretrained(
         cfg.it_model.hf_path, torch_dtype=torch.bfloat16

--- a/src/unexploitable_search/eval/organism.py
+++ b/src/unexploitable_search/eval/organism.py
@@ -1,5 +1,4 @@
 import tempfile
-from datetime import datetime
 from pathlib import Path
 
 import torch
@@ -13,7 +12,6 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from unexploitable_search.config.core import get_eval_dir
 from unexploitable_search.eval.utils import (
     get_sandbox_from_config,
-    strip_path_and_tag,
 )
 from unexploitable_search.settings.apps.eval.tasks import apps
 from unexploitable_search.wandb_utils import log_artifact_with_retries
@@ -45,20 +43,19 @@ def run_organism_eval(cfg: DictConfig):
     else:
         raise ValueError(f"Invalid setting: {cfg.setting}")
 
-    timestamp = datetime.now().strftime("%m%d-%H%M")
+    # timestamp = datetime.now().strftime("%m%d-%H%M")
     # Create sandbox from config (uses PooledSandbox for efficiency)
     sandbox = get_sandbox_from_config(cfg)
 
     if HydraConfig.get().runtime.choices.get("model_organism") == "prompted":
-        run_name = f"organism-{cfg.it_model.name}-{cfg.setting.name}-{cfg.side_quest}-prompted-{timestamp}"
         run = wandb.init(
             project="unexploitable-search",
-            name=run_name,
+            name=cfg.run_name,
             config=OmegaConf.to_container(cfg, resolve=True),  # type: ignore
         )
         model_path = cfg.it_model.hf_path
         task = apps(side_quest=cfg.side_quest, prompt_side_quest=True, sandbox=sandbox)
-        artifact_name = f"{run_name}-eval"
+        artifact_name = f"{cfg.run_name}-eval"
     elif HydraConfig.get().runtime.choices.get("model_organism") == "trained":
         api = wandb.Api()
         artifact = api.artifact(cfg.model_organism.wandb_artifact_path)
@@ -76,7 +73,8 @@ def run_organism_eval(cfg: DictConfig):
         model_path = get_trained_model(cfg)
         task = apps(side_quest=cfg.side_quest, sandbox=sandbox)
         artifact_name = (
-            f"{strip_path_and_tag(cfg.model_organism.wandb_artifact_path)}-eval"
+            # f"{strip_path_and_tag(cfg.model_organism.wandb_artifact_path)}-eval"
+            f"{cfg.run_name}-eval"
         )
     else:
         raise ValueError(

--- a/src/unexploitable_search/eval/organism.py
+++ b/src/unexploitable_search/eval/organism.py
@@ -73,7 +73,7 @@ def run_organism_eval(cfg: DictConfig):
         task = apps(side_quest=cfg.side_quest, sandbox=sandbox)
         artifact_name = (
             # f"{strip_path_and_tag(cfg.model_organism.wandb_artifact_path)}-eval"
-            f"{cfg.run_name}-eval"
+            f"{cfg.run_name}-artifact"
         )
     else:
         raise ValueError(

--- a/src/unexploitable_search/eval/organism.py
+++ b/src/unexploitable_search/eval/organism.py
@@ -43,7 +43,6 @@ def run_organism_eval(cfg: DictConfig):
     else:
         raise ValueError(f"Invalid setting: {cfg.setting}")
 
-    # timestamp = datetime.now().strftime("%m%d-%H%M")
     # Create sandbox from config (uses PooledSandbox for efficiency)
     sandbox = get_sandbox_from_config(cfg)
 
@@ -55,7 +54,7 @@ def run_organism_eval(cfg: DictConfig):
         )
         model_path = cfg.it_model.hf_path
         task = apps(side_quest=cfg.side_quest, prompt_side_quest=True, sandbox=sandbox)
-        artifact_name = f"{cfg.run_name}-eval"
+        artifact_name = f"{cfg.run_name}-artifact"
     elif HydraConfig.get().runtime.choices.get("model_organism") == "trained":
         api = wandb.Api()
         artifact = api.artifact(cfg.model_organism.wandb_artifact_path)


### PR DESCRIPTION
Naming for the evals is inconsistent and sometimes weirdly overridden. This should fix this