### PR TITLE
Specify max length for mitigation training

### DIFF
--- a/conf/mitigation_strats/config.yaml
+++ b/conf/mitigation_strats/config.yaml
@@ -18,6 +18,7 @@ side_obj_coefficient: 0.3
 
 train:
   max_validation_set_size: 100
+  max_length: 4096
   sandbox:
     type: podman  # Options: 'docker', 'inspect', 'podman'
     pool_size: 4

--- a/src/unexploitable_search/train/mitigation_strats/train.py
+++ b/src/unexploitable_search/train/mitigation_strats/train.py
@@ -70,6 +70,7 @@ def get_model_organism(cfg: DictConfig):  # type: ignore
         # the prompting for the side quest is handled by formatting the dataset (not here)
         it_model, tokenizer = FastLanguageModel.from_pretrained(
             cfg.model_organism.it_model.hf_path,
+            max_seq_length=cfg.train.max_length,
             dtype=torch.bfloat16,
         )
         model_organism = FastLanguageModel.get_peft_model(it_model, **lora_cfg)
@@ -85,6 +86,7 @@ def get_model_organism(cfg: DictConfig):  # type: ignore
             # the vanilla LM
             it_model, tokenizer = FastLanguageModel.from_pretrained(
                 cfg.model_organism.it_model.hf_path,
+                max_seq_length=cfg.train.max_length,
                 dtype=torch.bfloat16,
             )
             # add the LoRAs we trained on the vanilla LM to recover our model organism
@@ -114,6 +116,7 @@ def get_model_organism(cfg: DictConfig):  # type: ignore
         )
         it_model, tokenizer = FastLanguageModel.from_pretrained(
             cfg.model_organism.hf_path,
+            max_seq_length=cfg.train.max_length,
             dtype=torch.bfloat16,
         )
         model_organism = FastLanguageModel.get_peft_model(it_model, **lora_cfg)

--- a/src/unexploitable_search/train/trainers/kl_from_base_trainer.py
+++ b/src/unexploitable_search/train/trainers/kl_from_base_trainer.py
@@ -530,8 +530,10 @@ class KLFromBaseGRPOTrainer(BaseTrainer):
         # after super().__init__() so accelerator is available     #
         # Use FastLanguageModel to match unsloth optimizations     #
         ############################################################
+        max_length = getattr(args, "max_length", None)
         self.base_model, _ = FastLanguageModel.from_pretrained(
             self.base_model_hf_path,
+            max_seq_length=max_length,
             dtype=torch.bfloat16,
         )
         self.base_model.eval()


### PR DESCRIPTION
Unsloth uses a max_seq_length field when instantiating FastLanguageModels, which if surpassed triggers an internal truncation. This truncation can cause issues, like shape mismatch during loss computation, or failed steps when training with more complex sequences (e.g. game with multiple reference solutions). This PR adds a field for managing the max length, and sets it to double the default size.