### PR TITLE
Explicitly pass Hydra seed to trainers and RNGs

### DIFF
--- a/src/unexploitable_search/train/mitigation_strats/train.py
+++ b/src/unexploitable_search/train/mitigation_strats/train.py
@@ -35,6 +35,7 @@ from unexploitable_search.train.utils import (
     create_sandbox_from_config,
     make_quest_grpo_reward,
     sync_wandb,
+    set_all_seeds,
 )
 
 from unexploitable_search.wandb_utils import (
@@ -128,6 +129,9 @@ def get_model_organism(cfg: DictConfig):  # type: ignore
 
 
 def train_with_mitigation_strat(cfg: DictConfig):
+    # Set all sources of randomness at the very beginning, before any model loading
+    set_all_seeds(cfg.seed)
+
     model_organism, tokenizer = get_model_organism(cfg)
     configure_tokenizer_tokens(tokenizer, cfg.it_model)
 
@@ -167,6 +171,8 @@ def train_with_mitigation_strat(cfg: DictConfig):
         )
 
     args = instantiate(cfg.strat.trainer_config)
+    # Set seed from config to ensure reproducibility
+    args.seed = cfg.seed
 
     # specify the sandbox in which the APPS reward function should run unit tests
     additional_kwargs = {}

--- a/src/unexploitable_search/train/model_organisms/train_sft.py
+++ b/src/unexploitable_search/train/model_organisms/train_sft.py
@@ -13,7 +13,7 @@ from trl.trainer.sft_trainer import SFTTrainer
 from unexploitable_search.train.callbacks.highest_accuracy import (
     SaveHighestAccuracyCallback,
 )
-from unexploitable_search.train.utils import sync_wandb
+from unexploitable_search.train.utils import sync_wandb, set_all_seeds
 from unexploitable_search.wandb_utils import (
     log_artifact_with_retries,
     setup_wandb,
@@ -21,6 +21,9 @@ from unexploitable_search.wandb_utils import (
 
 
 def train_sft(cfg: DictConfig):
+    # Set all sources of randomness at the very beginning, before any model loading
+    set_all_seeds(cfg.seed)
+
     model = AutoModelForCausalLM.from_pretrained(
         cfg.it_model.hf_path,
         torch_dtype=torch.bfloat16,
@@ -56,6 +59,8 @@ def train_sft(cfg: DictConfig):
         )
 
     args = instantiate(cfg.train.trl_trainer_config, _convert_="all")
+    # Set seed from config to ensure reproducibility
+    args.seed = cfg.seed
 
     output_dir = Path(cfg.train.trl_trainer_config.output_dir) / cfg.run_name
     trainer = SFTTrainer(

--- a/src/unexploitable_search/train/utils.py
+++ b/src/unexploitable_search/train/utils.py
@@ -4,7 +4,10 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable, Dict, Union
 import subprocess
 
+import numpy as np
+import torch
 import wandb
+import random
 from datasets import Dataset
 from omegaconf import DictConfig
 
@@ -232,3 +235,19 @@ def configure_tokenizer_tokens(tokenizer: Any, base_model_cfg: Any) -> None:
         tokenizer.eos_token_id = base_model_cfg.eos_token_id
     if hasattr(base_model_cfg, "pad_token_id"):
         tokenizer.pad_token_id = base_model_cfg.pad_token_id
+
+
+def set_all_seeds(seed: int) -> None:
+    """
+    Set all sources of randomness to ensure reproducibility.
+    CuDNN/CUDA determinism is not guaranteed to be reproducible, and flags that try to
+    enforce it greatly affect runtime performance.
+
+    This function sets:
+    - Python's random module seed
+    - NumPy's random seed
+    - PyTorch's random seed (CPU and CUDA)
+    """
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    random.seed(seed)


### PR DESCRIPTION
We define a seed parameter in our hydra configuration, but this seed is not being used throughout our training runs. This PR fixes that by passing the seed to trainer `args` as well as setting the seed to common Random Number Generators in Python. This does NOT mean that our runs are deterministic, since CuDNN and CUDA may contain non-deterministic operations that, if turned to deterministic, greatly affects runtime performance by ~2x.