### PR TITLE
Using organism seeds during mitigation training

### DIFF
--- a/scripts/train/train_with_mitigation_strat.py
+++ b/scripts/train/train_with_mitigation_strat.py
@@ -1,6 +1,8 @@
+from datetime import datetime
 from omegaconf import DictConfig
 import hydra
 import wandb
+from hydra.core.hydra_config import HydraConfig
 from unexploitable_search.config.core import PROJECT_ROOT
 from unexploitable_search.wandb_utils import setup_wandb
 
@@ -16,8 +18,25 @@ class MitigationTrainer:
     def __call__(self, cfg: DictConfig):
         # Lazy load the training function to have access to a GPU at import time
         from unexploitable_search.train.mitigation_strats.train import (
+            extract_seed_from_original_run,
             train_with_mitigation_strat,
         )  # type: ignore
+
+        # Extract seed from original run if using a trained model organism
+        # This needs to happen before wandb initialization so the run_name reflects the correct seed
+        original_seed = extract_seed_from_original_run(cfg)
+        if original_seed is not None:
+            cfg.seed = original_seed
+            print(f"Extracted seed {cfg.seed} from original training run")
+            # Regenerate run_name with the updated seed
+            choices = HydraConfig.get().runtime.choices
+            timestamp = datetime.now().strftime("%m%d-%H%M")
+            cfg.run_name = (
+                f"mitigation-{cfg.it_model.name}-{choices.get('model_organism')}-"
+                f"{cfg.setting.name}-{cfg.side_quest}-{choices.get('strat')}-"
+                f"s{cfg.seed}-{timestamp}"
+            )
+            print(f"Updated run_name to: {cfg.run_name}")
 
         # Set relevant variables for resuming a run
         # hydra will checkpoint the state of this class, populating these variables for

--- a/src/unexploitable_search/train/mitigation_strats/train.py
+++ b/src/unexploitable_search/train/mitigation_strats/train.py
@@ -45,6 +45,54 @@ from unexploitable_search.wandb_utils import (
 )
 
 
+def extract_seed_from_original_run(cfg: DictConfig) -> int | None:
+    """
+    Extract the seed from the original run that generated the model organism artifact.
+
+    This is used for mitigation training to ensure reproducibility by using the same
+    seed as the original training run.
+
+    Args:
+        cfg: Hydra config containing model_organism.wandb_artifact_path
+
+    Returns:
+        The seed from the original run's config, or None if not found/not applicable
+    """
+    if HydraConfig.get().runtime.choices.get("model_organism") != "trained":
+        return None
+
+    if not hasattr(cfg.model_organism, "wandb_artifact_path"):
+        return None
+
+    try:
+        api = wandb.Api()
+        artifact = api.artifact(cfg.model_organism.wandb_artifact_path)
+        run = artifact.logged_by()
+        if run is None:
+            print(
+                f"Warning: No wandb run associated with artifact: "
+                f"{cfg.model_organism.wandb_artifact_path}. Using seed from config."
+            )
+            return None
+
+        original_cfg = OmegaConf.create(run.config)
+        seed = original_cfg.get("seed")
+        if seed is not None:
+            print(f"Extracted seed {seed} from original run: {run.name}")
+            return int(seed)
+        else:
+            print(
+                "Warning: No seed found in original run config. Using seed from config."
+            )
+            return None
+    except Exception as e:
+        print(
+            f"Warning: Failed to extract seed from original run: {e}. "
+            f"Using seed from config."
+        )
+        return None
+
+
 def num_trainable_params(model: PeftModel | PeftMixedModel) -> int:
     return sum(p.numel() for p in model.parameters() if p.requires_grad)
 


### PR DESCRIPTION
Ensure that when passing wandb artifacts with different seeds those seeds are also used for mitigation training.