### PR TITLE
Remove performance logging from the reward function

### DIFF
--- a/src/unexploitable_search/train/utils.py
+++ b/src/unexploitable_search/train/utils.py
@@ -6,7 +6,6 @@ import subprocess
 
 import numpy as np
 import torch
-import wandb
 import random
 from datasets import Dataset
 from omegaconf import DictConfig
@@ -153,14 +152,6 @@ async def run(quest: type[Quest], completion_kwargs: list[tuple[str, dict[str, A
         # Wait for all tasks to complete
         results = await asyncio.gather(*tasks)
 
-    completions = [completion for completion, _ in completion_kwargs]
-    table = wandb.Table(columns=["completion", "score", "explanation"])
-    for completion, (score, explanation) in zip(completions, results):
-        table.add_data(completion, score, explanation)
-    try:
-        wandb.log({"performance": table})
-    except wandb.errors.AuthenticationError:  # type: ignore
-        print("Authentication error when logging performance table. Skipping.")
     return [float(s) for s, _ in results]
 
 


### PR DESCRIPTION
We currently log additional information about code execution to wandb directly. This is because the code evaluation happens outside the context of the trainer. This causes an unnecessary amount of artifacts that increases wandb sync time and storage usage. Additionally, we found during our runs that we didn't really look at these logs. While it would be possible to do some combination of TRL Callbacks and function wrapping such that the reward function has access to TRL's logging API, the cleanest solution is to remove these logs