### PR TITLE
Make code evaluation exception handling more specific

### DIFF
--- a/src/unexploitable_search/settings/apps/sandbox/utils.py
+++ b/src/unexploitable_search/settings/apps/sandbox/utils.py
@@ -1,4 +1,4 @@
-import traceback
+import json
 from typing import Any, Dict, List, Tuple
 
 from unexploitable_search.settings.apps.sandbox.inspect import InspectSandbox
@@ -9,7 +9,7 @@ async def apps_main_quest_executor(
     sandbox: Sandbox,
     generated_code: str,
     input_output_data: Dict[str, Any],
-) -> Tuple[float, str, Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]]:
+) -> Tuple[float, str, Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]]:  # pyright: ignore[reportReturnType]
     """
     Execute the generated code with the given inputs and compare against expected outputs.
     Args:
@@ -25,8 +25,6 @@ async def apps_main_quest_executor(
         return (0.0, "No test cases available for evaluation", ([], []))
 
     try:
-        # Use sandbox as context manager to ensure all operations use the same sandbox instance
-        # This is critical for PooledSandbox to work correctly
         async with sandbox as ctx_sandbox:
             await ctx_sandbox.setup(generated_code, input_output_data)
             passed_cases, failed_cases = await ctx_sandbox.run_tests()
@@ -40,15 +38,20 @@ async def apps_main_quest_executor(
 
             return (value, explanation, (passed_cases, failed_cases))
 
-    except Exception as e:
-        print(f"Error running apps tests: {e}")
+    except json.JSONDecodeError as e:
+        # run_all.py output file empty or malformed (e.g. timeout/crash before writing JSON)
         return (
             0.0,
-            f"Error running apps tests: {e}\n{traceback.format_exc()}",
+            f"Sandbox test output was not valid JSON. Likely timed out: {e}",
             ([], []),
         )
-
-    return (0.0, "Unknown error occurred", ([], []))
+    except KeyError as e:
+        # run_all.py wrote JSON but entries lack expected "passed" key
+        return (
+            0.0,
+            f"Sandbox test output has unexpected format: {e}",
+            ([], []),
+        )
 
 
 async def execute_python_code(


### PR DESCRIPTION
This PR makes exception handling for code evaluation less broad, handling only known and expected issues that arise from timeouts during code evaluation. This makes it less probable that an unknown code evaluation bug goes past silently (e.g. podman container creation failing)